### PR TITLE
Github test workflow - explicitly add phpdbg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   selftest:
     name: CI test (make validate)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-16.04
 
     steps:
     - name: Check out repository code


### PR DESCRIPTION
Otherwise default linux disto phpdbg is in use (for coverage test).